### PR TITLE
d2rl

### DIFF
--- a/human_aware_rl/ppo/ppo_rllib.py
+++ b/human_aware_rl/ppo/ppo_rllib.py
@@ -23,6 +23,8 @@ class RllibPPOModel(TFModelV2):
         size_hidden_layers = custom_params["SIZE_HIDDEN_LAYERS"]
         num_filters = custom_params["NUM_FILTERS"]
         num_convs = custom_params["NUM_CONV_LAYERS"]
+        d2rl = custom_params["D2RL"]
+        assert type(d2rl) == bool
 
         ## Create graph of custom network. It will under a shared tf scope such that all agents
         ## use the same model
@@ -51,8 +53,11 @@ class RllibPPOModel(TFModelV2):
             )(out)
         
         # Apply dense hidden layers, if any
-        out = tf.keras.layers.Flatten()(out)
-        for _ in range(num_hidden_layers):
+        conv_out = tf.keras.layers.Flatten()(out)
+        out = conv_out
+        for i in range(num_hidden_layers):
+            if i > 0 and d2rl:
+                out = tf.keras.layers.Concatenate()([out, conv_out])
             out = tf.keras.layers.Dense(size_hidden_layers)(out)
             out = tf.keras.layers.LeakyReLU()(out)
 

--- a/human_aware_rl/ppo/ppo_rllib_client.py
+++ b/human_aware_rl/ppo/ppo_rllib_client.py
@@ -74,8 +74,8 @@ def my_config():
     # LSTM memory cell size (only used if use_lstm=True)
     CELL_SIZE = 256
 
-
-
+    # whether to use D2RL https://arxiv.org/pdf/2010.09163.pdf (concatenation the result of last conv layer to each hidden layer); works only when use_lstm is False
+    D2RL = False
     ### Training Params ###
 
     num_workers = 30 if not LOCAL_TESTING else 2
@@ -228,7 +228,8 @@ def my_config():
         "SIZE_HIDDEN_LAYERS" : SIZE_HIDDEN_LAYERS,
         "NUM_FILTERS" : NUM_FILTERS,
         "NUM_CONV_LAYERS" : NUM_CONV_LAYERS,
-        "CELL_SIZE" : CELL_SIZE
+        "CELL_SIZE" : CELL_SIZE,
+        "D2RL": D2RL
     }
 
     # to be passed into the rllib.PPOTrainer class

--- a/human_aware_rl/ppo/ppo_rllib_from_params_client.py
+++ b/human_aware_rl/ppo/ppo_rllib_from_params_client.py
@@ -93,7 +93,7 @@ def my_config():
     SIZE_HIDDEN_LAYERS = 64
     NUM_FILTERS = 25
     NUM_CONV_LAYERS = 3
-
+    D2RL = False
     # LSTM memory cell size (only used if use_lstm=True)
     CELL_SIZE = 256
 
@@ -261,7 +261,8 @@ def my_config():
         "SIZE_HIDDEN_LAYERS" : SIZE_HIDDEN_LAYERS,
         "NUM_FILTERS" : NUM_FILTERS,
         "NUM_CONV_LAYERS" : NUM_CONV_LAYERS,
-        "CELL_SIZE" : CELL_SIZE
+        "CELL_SIZE" : CELL_SIZE,
+        "D2RL": D2RL
     }
 
     # to be passed into the rllib.PPOTrainer class


### PR DESCRIPTION
Added change from this paper: https://arxiv.org/pdf/2010.09163.pdf
Example use:
`python ppo_rllib_client.py with seeds="[123]" D2RL=True`
Seems to give improvement on counter_curcuit, for example:
`python ppo_rllib_client.py with seeds="[123, 124, 125, 126, 127]" num_workers=8 num_gpus=1 layout_name="counter_circuit" num_training_iters=500 train_batch_size=12800 evaluation_interval=100 sgd_minibatch_size=8000 use_phi=False entropy_coeff_start=0.2 entropy_coeff_end=0.0005 lr=1e-3 num_sgd_iter=8 SIZE_HIDDEN_LAYERS=64 NUM_HIDDEN_LAYERS=16 D2RL=True` work better compared to setting D2RL flag on False.