### PR TITLE
update test thresholds

### DIFF
--- a/human_aware_rl/ppo/ppo_rllib_test.py
+++ b/human_aware_rl/ppo/ppo_rllib_test.py
@@ -154,6 +154,7 @@ class TestPPORllib(unittest.TestCase):
         results = ex.run(
             config_updates={
                 # Please feel free to modify the parameters below
+                "lr": 5e-3,
                 "results_dir": self.temp_results_dir,
                 "num_workers": 2,
                 "train_batch_size": 800,
@@ -169,7 +170,8 @@ class TestPPORllib(unittest.TestCase):
             options={"--loglevel": "ERROR"},
         ).result
         # Sanity check (make sure it begins to learn to receive dense reward)
-        self.assertGreaterEqual(results["average_total_reward"], self.min_performance)
+        # performance benchmark hardcoded by comparing exp runs with and without SGD enabled 
+        self.assertGreaterEqual(results["average_total_reward"], 8)
 
         if self.compute_pickle:
             self.expected["test_ppo_sp_no_phi"] = results
@@ -183,6 +185,7 @@ class TestPPORllib(unittest.TestCase):
         results = ex.run(
             config_updates={
                 # Please feel free to modify the parameters below
+                "lr": 5e-3,
                 "results_dir": self.temp_results_dir,
                 "num_workers": 2,
                 "train_batch_size": 1600,
@@ -198,7 +201,8 @@ class TestPPORllib(unittest.TestCase):
             options={"--loglevel": "ERROR"},
         ).result
         # Sanity check (make sure it begins to learn to receive dense reward)
-        self.assertGreaterEqual(results["average_total_reward"], self.min_performance)
+        # performance benchmark hardcoded by comparing exp runs with and without SGD enabled 
+        self.assertGreaterEqual(results["average_total_reward"], 15)
 
         if self.compute_pickle:
             self.expected["test_ppo_sp_yes_phi"] = results
@@ -220,7 +224,7 @@ class TestPPORllib(unittest.TestCase):
                 "use_phi": False,
                 "entropy_coeff_start": 0.0002,
                 "entropy_coeff_end": 0.00005,
-                "lr": 7e-4,
+                "lr": 5e-3,
                 "seeds": [0],
                 "outer_shape": (5, 4),
                 "evaluation_display": False,
@@ -229,7 +233,8 @@ class TestPPORllib(unittest.TestCase):
             options={"--loglevel": "ERROR"},
         ).result
         # Sanity check (make sure it begins to learn to receive dense reward)
-        self.assertGreaterEqual(results["average_total_reward"], self.min_performance)
+        # performance benchmark hardcoded by comparing exp runs with and without SGD enabled
+        self.assertGreaterEqual(results["average_total_reward"], 7.5)
 
         if self.compute_pickle:
             self.expected["test_ppo_fp_sp_no_phi"] = results
@@ -242,6 +247,7 @@ class TestPPORllib(unittest.TestCase):
         # Train a self play agent for 20 iterations
         results = ex_fp.run(
             config_updates={
+                "lr": 7e-4,
                 "results_dir": self.temp_results_dir,
                 "num_workers": 2,
                 "train_batch_size": 1600,
@@ -251,7 +257,6 @@ class TestPPORllib(unittest.TestCase):
                 "use_phi": True,
                 "entropy_coeff_start": 0.0002,
                 "entropy_coeff_end": 0.00005,
-                "lr": 7e-4,
                 "seeds": [0],
                 "outer_shape": (5, 4),
                 "evaluation_display": False,
@@ -259,11 +264,9 @@ class TestPPORllib(unittest.TestCase):
             },
             options={"--loglevel": "ERROR"},
         ).result
-        print(results["average_total_reward"])
-
 
         # Sanity check (make sure it begins to learn to receive dense reward)
-        self.assertGreaterEqual(results["average_total_reward"], self.min_performance)
+        self.assertGreaterEqual(results["average_total_reward"], 14)
 
         if self.compute_pickle:
             self.expected["test_ppo_fp_sp_yes_phi"] = results


### PR DESCRIPTION
# Description

Updated PPO tests benchmarks so they can detect whether learnings are being performed. Values are hardcoded by changing hyperparameters and comparing outcomes.

test_ppo_bc has an especially narrow margin, and it is hard to find a good cut-off value. Leaving it unchanged for now, and if there are problems with PPO agent implementation hopefully other tests can catch them. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
